### PR TITLE
LIB-107 Install ttf-dejavu font in alpine-musl for jdk 13

### DIFF
--- a/docker/repos/liberica-openjdk-alpine-musl/13/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/13/Dockerfile
@@ -23,6 +23,7 @@ ARG LIBERICA_GLIBC=no
 RUN RTAG="$LIBERICA_RELEASE_TAG" && if [ "x${RTAG}" = "x" ]; then RTAG="$LIBERICA_VERSION"; fi && \
   RSUFFIX="" && if [ "$LIBERICA_IMAGE_VARIANT" = "lite" ]; then RSUFFIX="-lite"; fi && \
   LIBSUFFIX="" && if [ "$LIBERICA_GLIBC" = "no" ]; then LIBSUFFIX="-musl"; fi && \
+  apk add ttf-dejavu && \
   mkdir -p /tmp/java && \
   PKG=`echo "bellsoft-${LIBERICA_VARIANT}${LIBERICA_VERSION}-linux-${LIBERICA_ARCH}${LIBSUFFIX}${RSUFFIX}.tar.gz"` && \
   PKG_URL="https://download.bell-sw.com/java/${LIBERICA_VERSION}/${PKG}" && \


### PR DESCRIPTION
Add ttf-dejavu font to alpine-musl docker according to LIB-107 to jdk 13