### PR TITLE
Update to glibc 2.34 for glibc-based alpine

### DIFF
--- a/docker/repos/liberica-openjdk-alpine/11/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/11/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 

--- a/docker/repos/liberica-openjdk-alpine/17/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/17/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 

--- a/docker/repos/liberica-openjdk-alpine/21/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/21/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 

--- a/docker/repos/liberica-openjdk-alpine/22/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/22/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 

--- a/docker/repos/liberica-openjdk-alpine/8/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/8/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 

--- a/docker/repos/liberica-openjre-alpine/11/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/11/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 

--- a/docker/repos/liberica-openjre-alpine/17/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/17/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 

--- a/docker/repos/liberica-openjre-alpine/21/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/21/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 

--- a/docker/repos/liberica-openjre-alpine/22/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/22/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 

--- a/docker/repos/liberica-openjre-alpine/8/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/8/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim as glibc-base
 
-ARG GLIBC_VERSION=2.28
+ARG GLIBC_VERSION=2.34
 ARG GLIBC_PREFIX=/usr/glibc
 ARG LANG=en_US.UTF-8
 


### PR DESCRIPTION
Any reason for why very old version 2.28 of glibc is used?

I have the need to include a native library which requires a newer version of glibc.

This PR updates glibc to 2.34. I chose this version to minimize required changes; it builds without issues but newer versions needs additional changes.