### PR TITLE
Fix typos in Dockerfiles

### DIFF
--- a/docker/repos/liberica-openjdk-alpine-musl/11/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/11/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.20 as liberica
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### base-minimal: minimal image with compressed java.base module, Minimal VM and optional files stripped
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### standard: standard jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### standard: standard jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/17/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/17/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.20 as liberica
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### base-minimal: minimal image with compressed java.base module, Minimal VM and optional files stripped
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### standard: standard jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### standard: standard jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/21/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/21/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.20 as liberica
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### base-minimal: minimal image with compressed java.base module, Minimal VM and optional files stripped
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### standard: standard jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### standard: standard jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/22/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/22/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.20 as liberica
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### base-minimal: minimal image with compressed java.base module, Minimal VM and optional files stripped
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### standard: standard jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### standard: standard jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.2/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.2/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.3/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.3/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.4/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.4/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.5/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.5/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.6/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.6/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.11 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/12.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/12.0.0/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/12.0.1/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/12.0.1/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/12.0.2/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/12.0.2/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/13.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/13.0.0/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/13.0.1/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/13.0.1/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/13/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/13/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.11 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/14.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/14.0.0/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.11 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/14/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/14/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.11 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### full: full jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### full: full jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/15/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/15/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.11 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### standard: standard jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### standard: standard jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/16/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/16/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.13 as liberica
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base]
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### standard: standard jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### standard: standard jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/18/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/18/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.16 as liberica
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### base-minimal: minimal image with compressed java.base module, Minimal VM and optional files stripped
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### standard: standard jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### standard: standard jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/19/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/19/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.16 as liberica
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### base-minimal: minimal image with compressed java.base module, Minimal VM and optional files stripped
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### standard: standard jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### standard: standard jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en

--- a/docker/repos/liberica-openjdk-alpine-musl/old/20/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/20/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.18 as liberica
 ### base: minimal image with compressed java.base module, Server VM and optional files stripped, ~37 MB with Alpine base
 ### base-minimal: minimal image with compressed java.base module, Minimal VM and optional files stripped
 ### lite: lite image with minimal footprint and Server VM, ~ 100 MB
-### standard: standard jdk image with Server VM and jmods, can be used to create arbirary module set, ~180 MB
+### standard: standard jdk image with Server VM and jmods, can be used to create arbitrary module set, ~180 MB
 
 ENV  LANG=en_US.UTF-8 \
      LANGUAGE=en_US:en


### PR DESCRIPTION
Fix typo "arbirary" on Dockerfiles. It was correctly written on [README](https://github.com/bell-sw/Liberica/blob/ac99b690303258938fd02031560dbd44d4c67c81/docker/repos/liberica-openjdk-alpine-musl/README.md?plain=1#L159), but somehow wrong on the Dockerfile descriptions [1](https://github.com/bell-sw/Liberica/blob/ac99b690303258938fd02031560dbd44d4c67c81/docker/repos/liberica-openjdk-alpine-musl/old/15/Dockerfile#L7) [2](https://github.com/bell-sw/Liberica/blob/ac99b690303258938fd02031560dbd44d4c67c81/docker/repos/liberica-openjdk-alpine-musl/old/12.0.1/Dockerfile#L7) etc.

<br>
<br>
<br>

Thanks, 
Takha