### PR TITLE
Fix mixing case styles in 'FROM' instructions in Dockerfiles

### DIFF
--- a/docker/repos/liberica-openjdk-alpine-musl/11/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base|base-minimal]

--- a/docker/repos/liberica-openjdk-alpine-musl/17/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base|base-minimal]

--- a/docker/repos/liberica-openjdk-alpine-musl/21/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/21/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base|base-minimal]

--- a/docker/repos/liberica-openjdk-alpine-musl/22/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/22/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base|base-minimal]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.2/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.3/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.4/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.5/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/11.0.6/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/11.0.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/12.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/12.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/12.0.1/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/12.0.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/12.0.2/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/12.0.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/13.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/13.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/13.0.1/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/13.0.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/13/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/13/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/14.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/14.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/14/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/14/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[full|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/15/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/15/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/16/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/16/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13 as liberica
+FROM alpine:3.13 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/18/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/18/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as liberica
+FROM alpine:3.16 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base|base-minimal]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/19/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/19/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as liberica
+FROM alpine:3.16 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base|base-minimal]

--- a/docker/repos/liberica-openjdk-alpine-musl/old/20/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine-musl/old/20/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 as liberica
+FROM alpine:3.18 AS liberica
 
 ### Modify argument LIBERICA_IMAGE_VARIANT or redefine it via --build-arg parameter to have specific liberica image installed:
 ###    docker build . --build-arg LIBERICA_IMAGE_VARIANT=[standard|lite|base|base-minimal]

--- a/docker/repos/liberica-openjdk-alpine/11/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -41,7 +41,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
   rm -rf etc/rpc var include share bin sbin/[^l]*  \
 	lib/*.o lib/*.a lib/audit lib/gconv lib/getconf
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/17/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -41,7 +41,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
   rm -rf etc/rpc var include share bin sbin/[^l]*  \
 	lib/*.o lib/*.a lib/audit lib/gconv lib/getconf
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/21/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/21/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -41,7 +41,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
   rm -rf etc/rpc var include share bin sbin/[^l]*  \
 	lib/*.o lib/*.a lib/audit lib/gconv lib/getconf
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/22/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/22/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -41,7 +41,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
   rm -rf etc/rpc var include share bin sbin/[^l]*  \
 	lib/*.o lib/*.a lib/audit lib/gconv lib/getconf
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/8/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/10.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/10.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -31,7 +31,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 

--- a/docker/repos/liberica-openjdk-alpine/old/10.0.1/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/10.0.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -31,7 +31,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 

--- a/docker/repos/liberica-openjdk-alpine/old/10.0.2/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/10.0.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -31,7 +31,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 

--- a/docker/repos/liberica-openjdk-alpine/old/11.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/11.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/11.0.1/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/11.0.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/11.0.2/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/11.0.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/11.0.3/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/11.0.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/11.0.4/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/11.0.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/11.0.5/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/11.0.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/11.0.6/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/11.0.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/12.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/12.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/12.0.1/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/12.0.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/12.0.2/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/12.0.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/13.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/13.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/13.0.1/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/13.0.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/13/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/13/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/14.0.0/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/14.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/14/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/14/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/15/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/15/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/16/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/16/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.13 as liberica
+FROM alpine:3.13 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/18/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/18/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -41,7 +41,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
   rm -rf etc/rpc var include share bin sbin/[^l]*  \
 	lib/*.o lib/*.a lib/audit lib/gconv lib/getconf
 
-FROM alpine:3.16 as liberica
+FROM alpine:3.16 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/19/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/19/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -41,7 +41,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
   rm -rf etc/rpc var include share bin sbin/[^l]*  \
 	lib/*.o lib/*.a lib/audit lib/gconv lib/getconf
 
-FROM alpine:3.16 as liberica
+FROM alpine:3.16 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/20/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/20/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -41,7 +41,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
   rm -rf etc/rpc var include share bin sbin/[^l]*  \
 	lib/*.o lib/*.a lib/audit lib/gconv lib/getconf
 
-FROM alpine:3.18 as liberica
+FROM alpine:3.18 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/8u192/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/8u192/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -31,7 +31,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 

--- a/docker/repos/liberica-openjdk-alpine/old/8u202/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/8u202/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/8u212/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/8u212/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/8u222/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/8u222/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/8u232/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/8u232/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/8u242/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/8u242/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.11 as liberica
+FROM alpine:3.11 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjdk-alpine/old/9.0.1/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/9.0.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -31,7 +31,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 

--- a/docker/repos/liberica-openjdk-alpine/old/9.0.4/Dockerfile
+++ b/docker/repos/liberica-openjdk-alpine/old/9.0.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as glibc-base
+FROM debian:stable-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -31,7 +31,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.8 as liberica
+FROM alpine:3.8 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 

--- a/docker/repos/liberica-openjre-alpine/11/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjre-alpine/17/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjre-alpine/21/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/21/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjre-alpine/22/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/22/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz

--- a/docker/repos/liberica-openjre-alpine/8/Dockerfile
+++ b/docker/repos/liberica-openjre-alpine/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim as glibc-base
+FROM debian:10-slim AS glibc-base
 
 ARG GLIBC_VERSION=2.28
 ARG GLIBC_PREFIX=/usr/glibc
@@ -40,7 +40,7 @@ RUN cd /root/dest${GLIBC_PREFIX} && \
 
 #sbin/[^l]*
 
-FROM alpine:3.20 as liberica
+FROM alpine:3.20 AS liberica
 
 ARG GLIBC_PREFIX=/usr/glibc
 ARG EXT_GCC_LIBS_URL=https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.3.0-1-x86_64.pkg.tar.xz


### PR DESCRIPTION
As per [docker docs](https://docs.docker.com/reference/build-checks/from-as-casing/) it is recommended to keep instruction casing consistent, either all uppercase or lowercase. 
I tried to fix this issue by changing 'as' to 'AS' 
<br>
Thanks,
Takha