### PR TITLE
Update - use debian:12 as base for Liberica images

### DIFF
--- a/docker/repos/liberica-openjdk-debian/11/Dockerfile
+++ b/docker/repos/liberica-openjdk-debian/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN     apt-get update                              \
   &&    apt-get install -y curl fontconfig locales  \

--- a/docker/repos/liberica-openjdk-debian/17/Dockerfile
+++ b/docker/repos/liberica-openjdk-debian/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN     apt-get update                              \
   &&    apt-get install -y curl fontconfig locales  \

--- a/docker/repos/liberica-openjdk-debian/21/Dockerfile
+++ b/docker/repos/liberica-openjdk-debian/21/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN     apt-get update                              \
   &&    apt-get install -y curl fontconfig locales  \

--- a/docker/repos/liberica-openjdk-debian/23/Dockerfile
+++ b/docker/repos/liberica-openjdk-debian/23/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN     apt-get update                              \
   &&    apt-get install -y curl fontconfig locales  \

--- a/docker/repos/liberica-openjdk-debian/8/Dockerfile
+++ b/docker/repos/liberica-openjdk-debian/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN apt-get update && \
 	apt-get install -y curl fontconfig locales && \

--- a/docker/repos/liberica-openjre-debian/11/Dockerfile
+++ b/docker/repos/liberica-openjre-debian/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN     apt-get update                              \
   &&    apt-get install -y curl fontconfig locales  \

--- a/docker/repos/liberica-openjre-debian/17/Dockerfile
+++ b/docker/repos/liberica-openjre-debian/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN     apt-get update                              \
   &&    apt-get install -y curl fontconfig locales  \

--- a/docker/repos/liberica-openjre-debian/21/Dockerfile
+++ b/docker/repos/liberica-openjre-debian/21/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN     apt-get update                              \
   &&    apt-get install -y curl fontconfig locales  \

--- a/docker/repos/liberica-openjre-debian/23/Dockerfile
+++ b/docker/repos/liberica-openjre-debian/23/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN     apt-get update                              \
   &&    apt-get install -y curl fontconfig locales  \

--- a/docker/repos/liberica-openjre-debian/8/Dockerfile
+++ b/docker/repos/liberica-openjre-debian/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN     apt-get update                              \
   &&    apt-get install -y curl fontconfig locales  \


### PR DESCRIPTION
Update dockerfiles - use Debian 12 as base for Liberica images.